### PR TITLE
Handle close stream event

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,13 +7,13 @@ inherits(PostMessageStream, DuplexStream)
 
 function PostMessageStream (opts) {
   DuplexStream.call(this, {
-    objectMode: true,
+    objectMode: true
   })
 
   this._name = opts.name
   this._target = opts.target
   this._targetWindow = opts.targetWindow || window
-  this._origin = (opts.targetWindow ? '*' : location.origin)
+  this._origin = (opts.targetWindow ? '*' : window.location.origin)
 
   // initialization flags
   this._init = false
@@ -67,7 +67,7 @@ PostMessageStream.prototype._read = noop
 PostMessageStream.prototype._write = function (data, encoding, cb) {
   var message = {
     target: this._target,
-    data: data,
+    data: data
   }
   this._targetWindow.postMessage(message, this._origin)
   cb()

--- a/index.js
+++ b/index.js
@@ -34,7 +34,10 @@ PostMessageStream.prototype._onMessage = function (event) {
   if (event.source !== this._targetWindow) return
   if (typeof msg !== 'object') return
   if (msg.target !== this._name) return
-  if (!msg.data) return
+  if (!msg.data) {
+    this.push(null)
+    return
+  }
 
   if (!this._init) {
     // listen for handshake
@@ -68,6 +71,20 @@ PostMessageStream.prototype._write = function (data, encoding, cb) {
   }
   this._targetWindow.postMessage(message, this._origin)
   cb()
+}
+
+// when a stream is destroyed, send a null message so the other end can end the stream
+PostMessageStream.prototype._destroy = function (err, callback) {
+  if (err) {
+    this.emit('error', err)
+  }
+  var message = {
+    target: this._target,
+    data: null
+  }
+  this._targetWindow.postMessage(message, this._origin)
+
+  callback()
 }
 
 // util

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "post-message-stream",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Sets up a duplex object stream over window.postMessage",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hello,

When the stream created by this lib is closed, nothing happen.
I implemented the _destroy interface with a message null sent through the post message api that make the distant stream to be closed (this.push(null) close the stream)

I also use standardjs on the file as the style was very close to it. I understand if you don't want it.
I also bump the version (it still needs to be 'npm publish'ed)