### PR TITLE
Add Release & Publishing and License to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,22 @@ var messageStream = new PostMessageStream({
   
 })
 ```
+
+## Release & Publishing
+
+ The project follows the same release process as the other libraries in the MetaMask organization:
+
+ 1. Create a release branch
+     - For a typical release, this would be based on `master`
+     - To update an older maintained major version, base the release branch on the major version branch (e.g. `1.x`)
+ 2. Update the changelog
+ 3. Update version in package.json file (e.g. `yarn version --minor --no-git-tag-version`)
+ 4. Create a pull request targeting the base branch (e.g. master or 1.x)
+ 5. Code review and QA
+ 6. Once approved, the PR is squashed & merged
+ 7. The commit on the base branch is tagged
+ 8. The tag can be published as needed
+
+ ## License
+
+ This project is available under the [ISC license](./LICENSE).


### PR DESCRIPTION
This PR adds the "Release & Publishing" and "License" sections to the bottom of the README.