### PR TITLE
Use @MetaMask/devs for codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-*                                    @MetaMask/extension-devs
+*                                    @MetaMask/devs


### PR DESCRIPTION
This package is not necessarily extension-specific, so we should set the code owner to `@MetaMask/devs`.

Ref: #14 