### PR TITLE
Add StreamData and StreamMessage type guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:watch": "yarn test --watch"
   },
   "dependencies": {
+    "@metamask/utils": "^2.0.0",
     "readable-stream": "2.3.3"
   },
   "devDependencies": {

--- a/src/BasePostMessageStream.ts
+++ b/src/BasePostMessageStream.ts
@@ -1,11 +1,10 @@
 import { Duplex } from 'readable-stream';
+import { StreamData } from './utils';
 
 const noop = () => undefined;
 
 const SYN = 'SYN';
 const ACK = 'ACK';
-
-export type StreamData = string | Record<string, unknown>;
 
 export interface PostMessageEvent {
   data?: StreamData;

--- a/src/WindowPostMessageStream.ts
+++ b/src/WindowPostMessageStream.ts
@@ -1,8 +1,8 @@
 import {
   BasePostMessageStream,
   PostMessageEvent,
-  StreamData,
 } from './BasePostMessageStream';
+import { isValidStreamMessage } from './utils';
 
 interface WindowPostMessageStreamArgs {
   name: string;
@@ -74,14 +74,13 @@ export class WindowPostMessageStream extends BasePostMessageStream {
     if (
       (this._targetOrigin !== '*' && event.origin !== this._targetOrigin) ||
       event.source !== this._targetWindow ||
-      typeof message !== 'object' ||
-      message.target !== this._name ||
-      !message.data
+      !isValidStreamMessage(message) ||
+      message.target !== this._name
     ) {
       return;
     }
 
-    this._onData(message.data as StreamData);
+    this._onData(message.data);
   }
 
   _destroy(): void {

--- a/src/WorkerParentPostMessageStream.ts
+++ b/src/WorkerParentPostMessageStream.ts
@@ -1,9 +1,8 @@
 import {
   BasePostMessageStream,
   PostMessageEvent,
-  StreamData,
 } from './BasePostMessageStream';
-import { DEDICATED_WORKER_NAME } from './enums';
+import { DEDICATED_WORKER_NAME, isValidStreamMessage } from './utils';
 
 interface WorkerParentStreamArgs {
   worker: Worker;
@@ -47,12 +46,11 @@ export class WorkerParentPostMessageStream extends BasePostMessageStream {
   private _onMessage(event: PostMessageEvent): void {
     const message = event.data;
 
-    // validate message
-    if (typeof message !== 'object' || !message.data) {
+    if (!isValidStreamMessage(message)) {
       return;
     }
 
-    this._onData(message.data as StreamData);
+    this._onData(message.data);
   }
 
   _destroy(): void {

--- a/src/WorkerPostMessageStream.ts
+++ b/src/WorkerPostMessageStream.ts
@@ -4,9 +4,12 @@
 import {
   BasePostMessageStream,
   PostMessageEvent,
-  StreamData,
 } from './BasePostMessageStream';
-import { DEDICATED_WORKER_NAME } from './enums';
+import {
+  DEDICATED_WORKER_NAME,
+  isValidStreamMessage,
+  StreamData,
+} from './utils';
 
 /**
  * Worker-side dedicated web worker `postMessage` stream.
@@ -38,11 +41,7 @@ export class WorkerPostMessageStream extends BasePostMessageStream {
     const message = event.data;
 
     // validate message
-    if (
-      typeof message !== 'object' ||
-      message.target !== this._name ||
-      !message.data
-    ) {
+    if (!isValidStreamMessage(message) || message.target !== this._name) {
       return;
     }
 

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,1 +1,0 @@
-export const DEDICATED_WORKER_NAME = 'dedicatedWorker';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { WindowPostMessageStream } from './WindowPostMessageStream';
 export { WorkerPostMessageStream } from './WorkerPostMessageStream';
 export { WorkerParentPostMessageStream } from './WorkerParentPostMessageStream';
-export { PostMessageEvent, StreamData } from './BasePostMessageStream';
+export { PostMessageEvent } from './BasePostMessageStream';
+export { StreamData, StreamMessage } from './utils';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,29 @@
+import { isObject } from '@metamask/utils';
+
+export const DEDICATED_WORKER_NAME = 'dedicatedWorker';
+
+export type StreamData = number | string | Record<string, unknown> | unknown[];
+
+export interface StreamMessage {
+  data: StreamData;
+  [key: string]: unknown;
+}
+
+/**
+ * Checks whether the specified stream event message is valid per the
+ * expectations of this library.
+ *
+ * @param message - The stream event message property.
+ * @returns Whether the `message` is a valid stream message.
+ */
+export function isValidStreamMessage(
+  message: unknown,
+): message is StreamMessage {
+  return (
+    isObject(message) &&
+    Boolean(message.data) &&
+    (typeof message.data === 'number' ||
+      typeof message.data === 'object' ||
+      typeof message.data === 'string')
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1376,6 +1376,13 @@
   resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-9.0.0.tgz#22d4911b705f7e4e566efbdda0e37912da33e30f"
   integrity sha512-mWlLGQKjXXFOj9EtDClKSoTLeQuPW2kM1w3EpUMf4goYAQ+kLXCCa8pEff6h8ApWAnjhYmXydA1znQ2J4XvD+A==
 
+"@metamask/utils@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@metamask/utils/-/utils-2.0.0.tgz#fe7e970416a256751c429f4a5e96aec6c4366ba7"
+  integrity sha512-AZ63AhRxAZXll+/SEiyEXgrxuAL4yOj0ny4V36VgPmTDvt+7GrmVJWrQF3o5PZZWV6ooaHZ9291RZHRcKZm0HA==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"


### PR DESCRIPTION
Adds a `StreamMessage` and, by extension, `StreamData` type guard that we reuse throughout this package. The `StreamData` type was expanded to include numbers and arrays because these were in fact permitted. Note that the tests are completely unchanged.

There is one functional change here, which is that the streams will ignore `MessageEvent.data` values for which `Array.isArray()` returns true. Permitting this was an oversight, and I don't know of a case where this could happen in practice, but I'm nevertheless highlighting it here.