### PR TITLE
Add `worker_threads` streams

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,8 +18,27 @@ module.exports = {
   // original implementations, between each test. It does not affect mocked
   // modules.
   restoreMocks: true,
-  runner: '@jest-runner/electron',
-  testEnvironment: '@jest-runner/electron/environment',
-  testRegex: ['\\.test\\.(ts|js)$'],
+  projects: [
+    {
+      displayName: 'runner: default',
+      preset: 'ts-jest',
+      testRegex: ['\\.test\\.(ts|js)$'],
+      testPathIgnorePatterns: [
+        '<rootDir>/src/WebWorker/*',
+        '<rootDir>/src/window/*',
+      ],
+    },
+    {
+      displayName: 'runner: electron',
+      preset: 'ts-jest',
+      runner: '@jest-runner/electron',
+      testEnvironment: '@jest-runner/electron/environment',
+      testRegex: ['\\.test\\.(ts|js)$'],
+      testPathIgnorePatterns: [
+        '<rootDir>/src/node-thread/*',
+        '<rootDir>/src/node-process/*',
+      ],
+    },
+  ],
   testTimeout: 2500,
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -20,7 +20,7 @@ module.exports = {
   restoreMocks: true,
   projects: [
     {
-      displayName: 'runner: default',
+      displayName: 'Runner: default',
       preset: 'ts-jest',
       testRegex: ['\\.test\\.(ts|js)$'],
       testPathIgnorePatterns: [
@@ -29,14 +29,13 @@ module.exports = {
       ],
     },
     {
-      displayName: 'runner: electron',
+      displayName: 'Runner: Electron',
       preset: 'ts-jest',
       runner: '@jest-runner/electron',
       testEnvironment: '@jest-runner/electron/environment',
-      testRegex: ['\\.test\\.(ts|js)$'],
-      testPathIgnorePatterns: [
-        '<rootDir>/src/node-thread/*',
-        '<rootDir>/src/node-process/*',
+      testMatch: [
+        '<rootDir>/src/WebWorker/*.test.ts',
+        '<rootDir>/src/window/*.test.ts',
       ],
     },
   ],

--- a/scripts/build-test.sh
+++ b/scripts/build-test.sh
@@ -9,3 +9,4 @@ mkdir -p dist-test
 rm -rf dist-test/*
 browserify --standalone PostMessageStream ./dist/WebWorker/WorkerPostMessageStream.js > ./dist-test/WorkerPostMessageStream.js
 browserify --standalone PostMessageStream ./dist/node-process/ChildProcessMessageStream.js > ./dist-test/ChildProcessMessageStream.js
+browserify --im --node --standalone PostMessageStream ./dist/node-thread/ThreadMessageStream.js > ./dist-test/ThreadMessageStream.js

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -8,6 +8,8 @@ describe('post-message-stream', () => {
       'WorkerParentPostMessageStream',
       'ParentProcessMessageStream',
       'ChildProcessMessageStream',
+      'ParentThreadMessageStream',
+      'ThreadMessageStream',
     ];
 
     it('package has expected exports', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,5 +3,7 @@ export * from './WebWorker/WorkerPostMessageStream';
 export * from './WebWorker/WorkerParentPostMessageStream';
 export * from './node-process/ParentProcessMessageStream';
 export * from './node-process/ChildProcessMessageStream';
+export * from './node-thread/ParentThreadMessageStream';
+export * from './node-thread/ThreadMessageStream';
 export { PostMessageEvent } from './BasePostMessageStream';
 export { StreamData, StreamMessage } from './utils';

--- a/src/node-thread/ParentThreadMessageStream.ts
+++ b/src/node-thread/ParentThreadMessageStream.ts
@@ -2,9 +2,9 @@ import { Worker } from 'worker_threads';
 import { BasePostMessageStream } from '../BasePostMessageStream';
 import { isValidStreamMessage, StreamData } from '../utils';
 
-type ParentThreadMessageStreamArgs = {
+interface ParentThreadMessageStreamArgs {
   process: Worker;
-};
+}
 
 export class ParentThreadMessageStream extends BasePostMessageStream {
   private _process: Worker;

--- a/src/node-thread/ParentThreadMessageStream.ts
+++ b/src/node-thread/ParentThreadMessageStream.ts
@@ -1,0 +1,37 @@
+import { Worker } from 'worker_threads';
+import { BasePostMessageStream } from '../BasePostMessageStream';
+import { isValidStreamMessage, StreamData } from '../utils';
+
+type ParentThreadMessageStreamArgs = {
+  process: Worker;
+};
+
+export class ParentThreadMessageStream extends BasePostMessageStream {
+  private _process: Worker;
+
+  constructor({ process }: ParentThreadMessageStreamArgs) {
+    super();
+
+    this._process = process;
+    this._onMessage = this._onMessage.bind(this);
+    this._process.on('message', this._onMessage);
+
+    this._handshake();
+  }
+
+  protected _postMessage(data: StreamData): void {
+    this._process.postMessage({ data });
+  }
+
+  private _onMessage(message: unknown): void {
+    if (!isValidStreamMessage(message)) {
+      return;
+    }
+
+    this._onData(message.data);
+  }
+
+  _destroy(): void {
+    this._process.removeListener('message', this._onMessage);
+  }
+}

--- a/src/node-thread/ThreadMessageStream.test.ts
+++ b/src/node-thread/ThreadMessageStream.test.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'stream';
 import { parentPort } from 'worker_threads';
 import { ThreadMessageStream } from './ThreadMessageStream';
 
+// This file is kept separate due to this module mock.
 jest.mock('worker_threads', () => ({
   parentPort: {
     on: jest.fn(),

--- a/src/node-thread/ThreadMessageStream.test.ts
+++ b/src/node-thread/ThreadMessageStream.test.ts
@@ -1,0 +1,46 @@
+import { EventEmitter } from "stream";
+import { parentPort } from "worker_threads";
+import { ThreadMessageStream } from "./ThreadMessageStream";
+
+jest.mock('worker_threads', () => ({ parentPort: { on: jest.fn(), postMessage: jest.fn(), removeListener: jest.fn() } }));
+
+describe('ThreadMessageStream', () => {
+
+    it('forwards valid messages', () => {
+        const emitter = new EventEmitter();
+        jest.spyOn(parentPort!, 'on').mockImplementation((event, listener) => emitter.on(event, listener) as any);
+        const stream = new ThreadMessageStream();
+        expect(parentPort!.on).toHaveBeenCalledWith('message', expect.any(Function));
+
+        const onDataSpy = jest
+            .spyOn(stream, '_onData' as any)
+            .mockImplementation();
+        emitter.emit('message', { data: 'bar' });
+
+        expect(onDataSpy).toHaveBeenCalledTimes(1);
+        expect(onDataSpy).toHaveBeenCalledWith('bar');
+    });
+
+    it('ignores invalid messages', () => {
+        const emitter = new EventEmitter();
+        jest.spyOn(parentPort!, 'on').mockImplementation((event, listener) => emitter.on(event, listener) as any);
+        const stream = new ThreadMessageStream();
+        const onDataSpy = jest
+            .spyOn(stream, '_onData' as any)
+            .mockImplementation();
+
+        [null, undefined, 'foo', 42, {}, { data: null }].forEach(
+            (invalidMessage) => {
+                emitter.emit('message', invalidMessage);
+
+                expect(onDataSpy).not.toHaveBeenCalled();
+            },
+        );
+    });
+
+    it('can be destroyed', () => {
+        const stream = new ThreadMessageStream();
+        stream.destroy();
+        expect(parentPort!.removeListener).toHaveBeenCalled();
+    })
+});

--- a/src/node-thread/ThreadMessageStream.test.ts
+++ b/src/node-thread/ThreadMessageStream.test.ts
@@ -1,46 +1,62 @@
-import { EventEmitter } from "stream";
-import { parentPort } from "worker_threads";
-import { ThreadMessageStream } from "./ThreadMessageStream";
+import { EventEmitter } from 'stream';
+import { parentPort } from 'worker_threads';
+import { ThreadMessageStream } from './ThreadMessageStream';
 
-jest.mock('worker_threads', () => ({ parentPort: { on: jest.fn(), postMessage: jest.fn(), removeListener: jest.fn() } }));
+jest.mock('worker_threads', () => ({
+  parentPort: {
+    on: jest.fn(),
+    postMessage: jest.fn(),
+    removeListener: jest.fn(),
+  },
+}));
 
 describe('ThreadMessageStream', () => {
+  it('forwards valid messages', () => {
+    const emitter = new EventEmitter();
+    jest
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      .spyOn(parentPort!, 'on')
+      .mockImplementation(
+        (event, listener) => emitter.on(event, listener) as any,
+      );
+    const stream = new ThreadMessageStream();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(parentPort!.on).toHaveBeenCalledWith(
+      'message',
+      expect.any(Function),
+    );
 
-    it('forwards valid messages', () => {
-        const emitter = new EventEmitter();
-        jest.spyOn(parentPort!, 'on').mockImplementation((event, listener) => emitter.on(event, listener) as any);
-        const stream = new ThreadMessageStream();
-        expect(parentPort!.on).toHaveBeenCalledWith('message', expect.any(Function));
+    const onDataSpy = jest.spyOn(stream, '_onData' as any).mockImplementation();
+    emitter.emit('message', { data: 'bar' });
 
-        const onDataSpy = jest
-            .spyOn(stream, '_onData' as any)
-            .mockImplementation();
-        emitter.emit('message', { data: 'bar' });
+    expect(onDataSpy).toHaveBeenCalledTimes(1);
+    expect(onDataSpy).toHaveBeenCalledWith('bar');
+  });
 
-        expect(onDataSpy).toHaveBeenCalledTimes(1);
-        expect(onDataSpy).toHaveBeenCalledWith('bar');
-    });
+  it('ignores invalid messages', () => {
+    const emitter = new EventEmitter();
+    jest
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      .spyOn(parentPort!, 'on')
+      .mockImplementation(
+        (event, listener) => emitter.on(event, listener) as any,
+      );
+    const stream = new ThreadMessageStream();
+    const onDataSpy = jest.spyOn(stream, '_onData' as any).mockImplementation();
 
-    it('ignores invalid messages', () => {
-        const emitter = new EventEmitter();
-        jest.spyOn(parentPort!, 'on').mockImplementation((event, listener) => emitter.on(event, listener) as any);
-        const stream = new ThreadMessageStream();
-        const onDataSpy = jest
-            .spyOn(stream, '_onData' as any)
-            .mockImplementation();
+    [null, undefined, 'foo', 42, {}, { data: null }].forEach(
+      (invalidMessage) => {
+        emitter.emit('message', invalidMessage);
 
-        [null, undefined, 'foo', 42, {}, { data: null }].forEach(
-            (invalidMessage) => {
-                emitter.emit('message', invalidMessage);
+        expect(onDataSpy).not.toHaveBeenCalled();
+      },
+    );
+  });
 
-                expect(onDataSpy).not.toHaveBeenCalled();
-            },
-        );
-    });
-
-    it('can be destroyed', () => {
-        const stream = new ThreadMessageStream();
-        stream.destroy();
-        expect(parentPort!.removeListener).toHaveBeenCalled();
-    })
+  it('can be destroyed', () => {
+    const stream = new ThreadMessageStream();
+    stream.destroy();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(parentPort!.removeListener).toHaveBeenCalled();
+  });
 });

--- a/src/node-thread/ThreadMessageStream.ts
+++ b/src/node-thread/ThreadMessageStream.ts
@@ -3,31 +3,31 @@ import { BasePostMessageStream } from '../BasePostMessageStream';
 import { isValidStreamMessage, StreamData } from '../utils';
 
 export class ThreadMessageStream extends BasePostMessageStream {
-    constructor() {
-        super();
+  constructor() {
+    super();
 
-        this._onMessage = this._onMessage.bind(this);
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        parentPort!.on('message', this._onMessage);
+    this._onMessage = this._onMessage.bind(this);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    parentPort!.on('message', this._onMessage);
 
-        this._handshake();
+    this._handshake();
+  }
+
+  protected _postMessage(data: StreamData): void {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    parentPort!.postMessage(data);
+  }
+
+  private _onMessage(message: unknown): void {
+    if (!isValidStreamMessage(message)) {
+      return;
     }
 
-    protected _postMessage(data: StreamData): void {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        parentPort!.postMessage(data);
-    }
+    this._onData(message.data);
+  }
 
-    private _onMessage(message: unknown): void {
-        if (!isValidStreamMessage(message)) {
-            return;
-        }
-
-        this._onData(message.data);
-    }
-
-    _destroy(): void {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        parentPort!.removeListener('message', this._onMessage);
-    }
+  _destroy(): void {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    parentPort!.removeListener('message', this._onMessage);
+  }
 }

--- a/src/node-thread/ThreadMessageStream.ts
+++ b/src/node-thread/ThreadMessageStream.ts
@@ -15,7 +15,7 @@ export class ThreadMessageStream extends BasePostMessageStream {
 
   protected _postMessage(data: StreamData): void {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    parentPort!.postMessage(data);
+    parentPort!.postMessage({ data });
   }
 
   private _onMessage(message: unknown): void {

--- a/src/node-thread/ThreadMessageStream.ts
+++ b/src/node-thread/ThreadMessageStream.ts
@@ -1,0 +1,33 @@
+import { parentPort } from 'worker_threads';
+import { BasePostMessageStream } from '../BasePostMessageStream';
+import { isValidStreamMessage, StreamData } from '../utils';
+
+export class ThreadMessageStream extends BasePostMessageStream {
+    constructor() {
+        super();
+
+        this._onMessage = this._onMessage.bind(this);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        parentPort!.on('message', this._onMessage);
+
+        this._handshake();
+    }
+
+    protected _postMessage(data: StreamData): void {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        parentPort!.postMessage(data);
+    }
+
+    private _onMessage(message: unknown): void {
+        if (!isValidStreamMessage(message)) {
+            return;
+        }
+
+        this._onData(message.data);
+    }
+
+    _destroy(): void {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        parentPort!.removeListener('message', this._onMessage);
+    }
+}

--- a/src/node-thread/node-thread.test.ts
+++ b/src/node-thread/node-thread.test.ts
@@ -1,8 +1,7 @@
 import EventEmitter from 'events';
 import { readFileSync, writeFileSync } from 'fs';
-import { ThreadMessageStream } from './ThreadMessageStream';
+import { Worker } from 'worker_threads';
 import { ParentThreadMessageStream } from './ParentThreadMessageStream';
-import { Worker } from 'worker_threads'
 
 const DIST_TEST_PATH = `${__dirname}/../../dist-test`;
 

--- a/src/node-thread/node-thread.test.ts
+++ b/src/node-thread/node-thread.test.ts
@@ -1,0 +1,84 @@
+import EventEmitter from 'events';
+import { readFileSync, writeFileSync } from 'fs';
+import { ThreadMessageStream } from './ThreadMessageStream';
+import { ParentThreadMessageStream } from './ParentThreadMessageStream';
+import { Worker } from 'worker_threads'
+
+const DIST_TEST_PATH = `${__dirname}/../../dist-test`;
+
+class MockProcess extends EventEmitter {
+  postMessage(..._args: any[]): void {
+    return undefined;
+  }
+}
+
+describe('Node Thread Streams', () => {
+  it('can communicate with a thread and be destroyed', async () => {
+    const dist = readFileSync(
+      `${DIST_TEST_PATH}/ThreadMessageStream.js`,
+      'utf8',
+    );
+
+    // Create a stream that multiplies incoming data by 5 and returns it
+    const setupProcessStream = `
+      const { ThreadMessageStream } = require('./ThreadMessageStream');
+      const stream = new ThreadMessageStream();
+      stream.on('data', (value) => stream.write(value * 5));
+    `;
+
+    const code = `${dist}\n${setupProcessStream}`;
+
+    const tmpFilePath = `${DIST_TEST_PATH}/thread-test.js`;
+    writeFileSync(tmpFilePath, code);
+
+    const process = new Worker(tmpFilePath);
+
+    // Create parent stream
+    const parentStream = new ParentThreadMessageStream({ process });
+
+    // Get a deferred Promise for the eventual result
+    const responsePromise = new Promise((resolve) => {
+      parentStream.once('data', (num) => {
+        resolve(Number(num));
+      });
+    });
+
+    // The child should ignore this
+    process.postMessage('foo');
+
+    // Send message to child, triggering a response
+    parentStream.write(111);
+
+    expect(await responsePromise).toStrictEqual(555);
+
+    // Check that events with falsy data are ignored as expected
+    parentStream.once('data', (data) => {
+      throw new Error(`Unexpected data on stream: ${data}`);
+    });
+    process.postMessage(new Event('message'));
+
+    // Terminate child process, destroy parent stream, and check that parent
+    // was destroyed
+    process.terminate();
+    parentStream.destroy();
+    expect(parentStream.destroyed).toStrictEqual(true);
+  });
+
+  describe('ParentThreadMessageStream', () => {
+    it('ignores invalid messages', () => {
+      const mockProcess: any = new MockProcess();
+      const stream = new ParentThreadMessageStream({ process: mockProcess });
+      const onDataSpy = jest
+        .spyOn(stream, '_onData' as any)
+        .mockImplementation();
+
+      [null, undefined, 'foo', 42, {}, { data: null }].forEach(
+        (invalidMessage) => {
+          mockProcess.emit('message', invalidMessage);
+
+          expect(onDataSpy).not.toHaveBeenCalled();
+        },
+      );
+    });
+  });
+});


### PR DESCRIPTION
Adds streams for the parent of a `worker_threads` `Worker` and the `Worker` itself. These communicate in a similar fashion to `child_process` but uses `postMessage` on `worker_threads` objects instead of a global.

`worker_threads` is not available in Electron, so this PR also changes some tests to run in JSDom instead of Electron.