### PR TITLE
Add browser entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "license": "ISC",
   "main": "dist/index.js",
+  "browser": "dist/browser.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist/"

--- a/src/browser.test.ts
+++ b/src/browser.test.ts
@@ -1,0 +1,22 @@
+import * as PostMessageStream from './browser';
+
+describe('post-message-stream', () => {
+  describe('browser exports', () => {
+    const expectedExports = [
+      'BasePostMessageStream',
+      'WindowPostMessageStream',
+      'WebWorkerPostMessageStream',
+      'WebWorkerParentPostMessageStream',
+    ];
+
+    it('package has expected exports', () => {
+      expect(Object.keys(PostMessageStream)).toHaveLength(
+        expectedExports.length,
+      );
+
+      for (const exportName of expectedExports) {
+        expect(exportName in PostMessageStream).toStrictEqual(true);
+      }
+    });
+  });
+});

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,0 +1,6 @@
+// Exports a subset of functionality for browsers
+export * from './window/WindowPostMessageStream';
+export * from './WebWorker/WebWorkerPostMessageStream';
+export * from './WebWorker/WebWorkerParentPostMessageStream';
+export * from './BasePostMessageStream';
+export { StreamData, StreamMessage } from './utils';


### PR DESCRIPTION
Adds a separate entry point for browser environments that omits Node.js exclusive streams. The entry point is added as the `browser` field in the `package.json`.