### PR TITLE
Update `prettier` to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "eslint-plugin-prettier": "^3.3.1",
     "jest": "^26.6.3",
     "jest-it-up": "^2.0.2",
-    "prettier": "^2.2.1",
+    "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.17",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.3.0",

--- a/src/WebWorker/WebWorker.test.ts
+++ b/src/WebWorker/WebWorker.test.ts
@@ -119,11 +119,13 @@ describe('WebWorker Streams', () => {
         .spyOn(stream, '_onData' as any)
         .mockImplementation();
 
-      ([
-        { data: 'bar' },
-        { data: { data: 'bar', target: 'foo' } },
-        { data: { data: null, target: 'foo' } },
-      ] as const).forEach((invalidMessage) => {
+      (
+        [
+          { data: 'bar' },
+          { data: { data: 'bar', target: 'foo' } },
+          { data: { data: null, target: 'foo' } },
+        ] as const
+      ).forEach((invalidMessage) => {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         self.onmessage!(new MessageEvent<unknown>('foo', invalidMessage));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6661,10 +6661,10 @@ prettier@^1.14.2:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
-prettier@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
-  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+prettier@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
 pretty-format@^25.5.0:
   version "25.5.0"


### PR DESCRIPTION
`prettier` has been updated to the latest version. This resolves a warning shown on the CLI when `yarn lint` was run about `--no-error-on-unmatched-pattern` being an unrecognized option.