### PR TITLE
Add fix for event security (MessageEvent source issue)

### DIFF
--- a/src/window/WindowPostMessageStream.ts
+++ b/src/window/WindowPostMessageStream.ts
@@ -11,6 +11,17 @@ interface WindowPostMessageStreamArgs {
   targetWindow?: Window;
 }
 
+// @ts-expect-error Object should be defined.
+const getSource = Object.getOwnPropertyDescriptor(
+  MessageEvent.prototype,
+  'source',
+).get;
+// @ts-expect-error Object should be defined.
+const getOrigin = Object.getOwnPropertyDescriptor(
+  MessageEvent.prototype,
+  'origin',
+).get;
+
 /**
  * A {@link Window.postMessage} stream.
  */
@@ -78,8 +89,11 @@ export class WindowPostMessageStream extends BasePostMessageStream {
     const message = event.data;
 
     if (
-      (this._targetOrigin !== '*' && event.origin !== this._targetOrigin) ||
-      event.source !== this._targetWindow ||
+      (this._targetOrigin !== '*' &&
+        // @ts-expect-error getOrigin should be defined.
+        getOrigin.call(event) !== this._targetOrigin) ||
+      // @ts-expect-error getSource should be defined.
+      getSource.call(event) !== this._targetWindow ||
       !isValidStreamMessage(message) ||
       message.target !== this._name
     ) {

--- a/src/window/WindowPostMessageStream.ts
+++ b/src/window/WindowPostMessageStream.ts
@@ -1,3 +1,4 @@
+import { assert } from '@metamask/utils';
 import {
   BasePostMessageStream,
   PostMessageEvent,
@@ -11,16 +12,25 @@ interface WindowPostMessageStreamArgs {
   targetWindow?: Window;
 }
 
-// @ts-expect-error Object should be defined.
-const getSource = Object.getOwnPropertyDescriptor(
+const getSourceDescriptor = Object.getOwnPropertyDescriptor(
   MessageEvent.prototype,
   'source',
-).get;
-// @ts-expect-error Object should be defined.
-const getOrigin = Object.getOwnPropertyDescriptor(
+);
+assert(
+  getSourceDescriptor,
+  'MessageEvent.prototype.source getter is not defined.',
+);
+const getSource = getSourceDescriptor.get;
+
+const getOriginDescriptor = Object.getOwnPropertyDescriptor(
   MessageEvent.prototype,
   'origin',
-).get;
+);
+assert(
+  getOriginDescriptor,
+  'MessageEvent.prototype.origin getter is not defined.',
+);
+const getOrigin = getOriginDescriptor.get;
 
 /**
  * A {@link Window.postMessage} stream.
@@ -88,11 +98,19 @@ export class WindowPostMessageStream extends BasePostMessageStream {
   private _onMessage(event: PostMessageEvent): void {
     const message = event.data;
 
+    assert(
+      getOrigin,
+      `Function was expected for 'getOrigin', but ${typeof getOrigin} was provided instead.`,
+    );
+
+    assert(
+      getSource,
+      `Function was expected for 'getSource', but ${typeof getSource} was provided instead.`,
+    );
+
     if (
       (this._targetOrigin !== '*' &&
-        // @ts-expect-error getOrigin should be defined.
         getOrigin.call(event) !== this._targetOrigin) ||
-      // @ts-expect-error getSource should be defined.
       getSource.call(event) !== this._targetWindow ||
       !isValidStreamMessage(message) ||
       message.target !== this._name

--- a/src/window/WindowPostMessageStream.ts
+++ b/src/window/WindowPostMessageStream.ts
@@ -12,25 +12,19 @@ interface WindowPostMessageStreamArgs {
   targetWindow?: Window;
 }
 
-const getSourceDescriptor = Object.getOwnPropertyDescriptor(
+/* istanbul ignore next */
+const getSource = Object.getOwnPropertyDescriptor(
   MessageEvent.prototype,
   'source',
-);
-assert(
-  getSourceDescriptor,
-  'MessageEvent.prototype.source getter is not defined.',
-);
-const getSource = getSourceDescriptor.get;
+)?.get;
+assert(getSource, 'MessageEvent.prototype.source getter is not defined.');
 
-const getOriginDescriptor = Object.getOwnPropertyDescriptor(
+/* istanbul ignore next */
+const getOrigin = Object.getOwnPropertyDescriptor(
   MessageEvent.prototype,
   'origin',
-);
-assert(
-  getOriginDescriptor,
-  'MessageEvent.prototype.origin getter is not defined.',
-);
-const getOrigin = getOriginDescriptor.get;
+)?.get;
+assert(getOrigin, 'MessageEvent.prototype.origin getter is not defined.');
 
 /**
  * A {@link Window.postMessage} stream.
@@ -98,25 +92,17 @@ export class WindowPostMessageStream extends BasePostMessageStream {
   private _onMessage(event: PostMessageEvent): void {
     const message = event.data;
 
-    assert(
-      getOrigin,
-      `Function was expected for 'getOrigin', but ${typeof getOrigin} was provided instead.`,
-    );
-
-    assert(
-      getSource,
-      `Function was expected for 'getSource', but ${typeof getSource} was provided instead.`,
-    );
-
+    /* eslint-disable @typescript-eslint/no-non-null-assertion */
     if (
       (this._targetOrigin !== '*' &&
-        getOrigin.call(event) !== this._targetOrigin) ||
-      getSource.call(event) !== this._targetWindow ||
+        getOrigin!.call(event) !== this._targetOrigin) ||
+      getSource!.call(event) !== this._targetWindow ||
       !isValidStreamMessage(message) ||
       message.target !== this._name
     ) {
       return;
     }
+    /* eslint-enable @typescript-eslint/no-non-null-assertion */
 
     this._onData(message.data);
   }


### PR DESCRIPTION
This PR will fix an issue after changing the prototype of the MessageEvent (source property).

This PR will unblock: https://github.com/MetaMask/snaps-monorepo/pull/1221

Related ticket: https://github.com/MetaMask/snaps-monorepo/issues/1132

### [Context](https://github.com/MetaMask/snaps-monorepo/issues/1132#issuecomment-1423004021)
* As part of the effort around securing snaps arch, we decided to scuttle all properties of Event based prototypes that might leak DOM/window objects.
* However, when performing such scuttling, this dep is being affected because it counts on having a direct access to those properties that we scuttle.
* We fix that by simply preserving the needed descriptors before we scuttle them so we can use them later instead of the direct props access.
