### PR TITLE
chore(devdeps): @lavamoat/allow-scripts@^2.3.1->^3.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@jest-runner/electron": "^3.0.1",
-    "@lavamoat/allow-scripts": "^2.3.1",
+    "@lavamoat/allow-scripts": "^3.0.4",
     "@metamask/auto-changelog": "^3.0.0",
     "@metamask/eslint-config": "^10.0.0",
     "@metamask/eslint-config-jest": "^10.0.0",
@@ -79,5 +79,6 @@
       "core-js": true,
       "electron": true
     }
-  }
+  },
+  "packageManager": "yarn@4.2.1+sha256.15ce76682a8cd2090257b883cd69c637925b29573f9573e8403ec227d5ab6815"
 }


### PR DESCRIPTION
Pin current (latest) yarn v1.x version in order to make `corepack enable` pick up the correct version when working with this repo.

### Related
- https://github.com/MetaMask/metamask-mobile/pull/9143