### PR TITLE
chore: declare yarn version 1.22.22 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,8 +66,10 @@
     "ts-jest": "^26.3.0",
     "typescript": "~4.4.0"
   },
+  "packageManager": "yarn@1.22.22",
   "engines": {
-    "node": "^16.20 || ^18.16 || >=20"
+    "node": "^16.20 || ^18.16 || >=20",
+    "yarn": "^1.22.22"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
Pin current (latest) yarn v1.x version in order to make `corepack enable` pick up the correct version when working with this repo.

### Related
- https://github.com/MetaMask/metamask-mobile/pull/9143
- https://github.com/MetaMask/action-utils/pull/35