### PR TITLE
Drop support for Node.js versions 16, 21

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,7 +11,10 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x]
+        node-version:
+          - 18.x
+          - 20.x
+          - 22.x
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "packageManager": "yarn@1.22.22",
   "engines": {
-    "node": "^16.20 || ^18.16 || >=20",
+    "node": "^18.18 || ^20.14 || >=22",
     "yarn": "^1.22.22"
   },
   "publishConfig": {


### PR DESCRIPTION
In preparation for dropping Node.js v16 support in `@metamask/utils`.